### PR TITLE
Adjust links after migration Passau -> Saarbrücken

### DIFF
--- a/links
+++ b/links
@@ -3,7 +3,7 @@ FeatureIDE;https://featureide.github.io/;fide;featureide;FeatureIDE
 FeatureHouse;http://www.infosun.fim.uni-passau.de/cl/apel/fh/;fh;featurehouse;FeatureHouse
 FeatureFoundation;http://www.infosun.fim.uni-passau.de/cl/FeatureFoundation/index_en.html;ff;FeatureFoundation
 FeatureC++;http://wwwiti.cs.uni-magdeburg.de/iti_db/forschung/fop/featurec/;fcc;fcpp
-Model Composition;http://www.infosun.fim.uni-passau.de/cl/staff/apel/mc/;mc
+Model Composition;https://www.se.cs.uni-saarland.de/apel/mc/;mc
 FOSD Workshop 2009;http://www.infosun.fim.uni-passau.de/cl/staff/apel/FOSD2009/;2009;FOSD2009;fosd2009
 FOSD Workshop 2010;http://www.infosun.fim.uni-passau.de/cl/staff/apel/FOSD2010/;2010;FOSD2010;fosd2010
 FOSD Workshop 2011;http://wwwiti.cs.uni-magdeburg.de/iti_db/workshops/FOSD11/;2011;FOSD2011;fosd2011
@@ -13,7 +13,7 @@ FOSD Workshop 2014;https://web.archive.org/web/20170402203423/http://gsd.uwaterl
 FOSD Workshop 2016;http://2016.splashcon.org/track/fosd2016;W2016;workshop2016
 Feature Featherweight Java;http://www.infosun.fim.uni-passau.de/cl/staff/apel/ffj/;ffj
 LJAR Technical Report;http://wwwiti.cs.uni-magdeburg.de/iti_db/forschung/cide/LJARTech;LJARTech
-Empirical Evaluation of Program Comprehension;http://www.infosun.fim.uni-passau.de/se/janet/;experiments;exp_cppcide
+Empirical Evaluation of Program Comprehension;https://www.tu-chemnitz.de/informatik/ST/research/material/;experiments;exp_cppcide
 CPPStats;http://www.infosun.fim.uni-passau.de/cl/staff/liebig/cppstats/;cppstats
 FOSD Treffen 2010 in Magdeburg;http://wwwiti.cs.uni-magdeburg.de/~ckaestne/fosdtreffen2010/;treffen2010
 FOSD Treffen 2011 in Dresden;http://fheidenreich.de/work/fosd-dresden-2011/;treffen2011
@@ -31,34 +31,33 @@ Fuji: Feature-Oriented Java Compiler;http://www.infosun.fim.uni-passau.de/cl/sta
 cnife: A tool for the transformation of #ifdefs into feature-modules;http://www.infosun.fim.uni-passau.de/cl/staff/liebig/cnife/;cnife
 FeatureVisu;http://featurevisu.sosy-lab.org/;FeatureVisu
 FeatureTweezer;http://www.infosun.fim.uni-passau.de/cl/staff/scholz/FeatureTweezer;FT;FeatureTweezer
-Feature Commander;http://www.infosun.fim.uni-passau.de/spl/janet/xenomai/;fc
+Feature Commander;https://www.tu-chemnitz.de/informatik/ST/research/material/xenomai/;fc
 Variability Mining with LEADT;https://github.com/ckaestne/LEADT;leadt
 Product-Line Testing (SharQ framework);http://www.sharq.tu-darmstadt.de/projects/index.en.jsp;tests
-Software Measures and Program Comprehension;https://www.infosun.fim.uni-passau.de/spl/janet/swm/index.php;swm;softwaremeasures
-SPL Conqueror;http://www.infosun.fim.uni-passau.de/se/projects/splconqueror/;SPLConqueror
-View Infinity:A Zoomable Interface for FOSD;http://www.infosun.fim.uni-passau.de/spl/janet/vi/;vi
-Feature-Aware Verification;http://www.infosun.fim.uni-passau.de/se/FAV;FAV
-Results of an empirical study on semistructured and unstructured merge;http://www.infosun.fim.uni-passau.de/se/SSMerge/;SSMerge
-PROPHET: Supporting Program-Comprehension Experiments;http://www.infosun.fim.uni-passau.de/spl/janet/prophet/;prophet
+Software Measures and Program Comprehension;https://www.tu-chemnitz.de/informatik/ST/research/material/swm/index.php;swm;softwaremeasures
+SPL Conqueror;https://www.se.cs.uni-saarland.de/projects/splconqueror/;SPLConqueror
+View Infinity:A Zoomable Interface for FOSD;https://www.tu-chemnitz.de/informatik/ST/research/material/vi;vi
+Feature-Aware Verification;https://www.se.cs.uni-saarland.de/projects/FAV;FAV
+Results of an empirical study on semistructured and unstructured merge;https://www.se.cs.uni-saarland.de/projects/SSMerge/;SSMerge
+PROPHET: Supporting Program-Comprehension Experiments;https://www.tu-chemnitz.de/informatik/ST/research/material/prophet/;prophet
 TypeChef: Type checking #ifdef variability (in the Linux kernel);http://ckaestne.github.com/TypeChef;TypeChef;typechef;Typechef
 SpeK: Composition of Feature-Oriented Specification given in the Java Modeling Language;http://www.infosun.fim.uni-passau.de/cl/staff/scholz/spek;spek;SpeK
-Measuring Programming Experience;http://www.infosun.fim.uni-passau.de/spl/janet/PE/;PE
-JDime: Structured Merge with Auto-Tuning;http://www.infosun.fim.uni-passau.de/se/JDime;JDime
+Measuring Programming Experience;https://www.tu-chemnitz.de/informatik/ST/research/material/PE/;PE
+JDime: Structured Merge with Auto-Tuning;https://www.se.cs.uni-saarland.de/projects/jdime/;JDime
 Analyses Strategies for Software Product Lines;http://wwwiti.cs.uni-magdeburg.de/iti_db/research/spl-strategies/;spl-strategies
 Does the Discipline of Preprocessor Annotations Matter? A Controlled Experiment;http://wwwiti.cs.uni-magdeburg.de/~sanschul/experiment/;experimentIfdef
-Scalable Analysis of Variable Software;http://www.infosun.fim.uni-passau.de/se/papers/va_experience/;vaa
-FeatureBite: A Feature-Oriented Composer for Java Bytecode;http://www.infosun.fim.uni-passau.de/se/projects/featurebite/index.html;featurebite
-Family-Based Measurement;http://www.infosun.fim.uni-passau.de/se/projects/family/;Family
-Variability in Open-Source and Industrial Software Systems;http://www.infosun.fim.uni-passau.de/se/papers/ESE2014/;oss_vs_is
-Morpheus: Variability-Aware Refactoring in the Wild;http://www.infosun.fim.uni-passau.de/se/projects/morpheus/;morpheus
-Presence-Condition Simplification;http://www.infosun.fim.uni-passau.de/se/projects/PresenceConditionSimplification/;pcsimp
+Scalable Analysis of Variable Software;https://www.se.cs.uni-saarland.de/papers/va_experience/;vaa
+FeatureBite: A Feature-Oriented Composer for Java Bytecode;https://www.se.cs.uni-saarland.de/projects/featurebite/index.html;featurebite
+Family-Based Measurement;https://www.se.cs.uni-saarland.de/projects/family/;Family
+Variability in Open-Source and Industrial Software Systems;https://www.se.cs.uni-saarland.de/papers/ESE2014/;oss_vs_is
+Morpheus: Variability-Aware Refactoring in the Wild;https://www.se.cs.uni-saarland.de/projects/morpheus/;morpheus
+Presence-Condition Simplification;https://www.se.cs.uni-saarland.de/projects/PresenceConditionSimplification/;pcsimp
 Variability-Aware Execution for PHP;https://web.archive.org/web/20141024164921/http://home.engineering.iastate.edu/~hungnv/Research/Varex/;varex;Varex;VarEx
 Analyzing Embedded HTML Code in PHP;https://web.archive.org/web/20150623052817/http://home.engineering.iastate.edu:80/~hungnv/Research/Varis/;varis
 Contracts for Software Product Lines;http://wwwiti.cs.uni-magdeburg.de/iti_db/research/spl-contracts/;spl-contracts
 Survey on Tools for FOSD;http://wwwiti.cs.uni-magdeburg.de/iti_db/research/fosd-tools/;tools
-SPLConqueror-FSE15;http://www.infosun.fim.uni-passau.de/se/projects/splconqueror/esecfse2015.php;SPLConqueror-FSE15
-SIFTA: Scalable Analysis of Inter-App Communication;http://www.infosun.fim.uni-passau.de/se/papers/app_analysis/;siftaeval
-;http://www.infosun.fim.uni-passau.de/se/rhein/thesis/;vonRhein
+SPLConqueror-FSE15;https://www.se.cs.uni-saarland.de/projects/splconqueror/esecfse2015.php;SPLConqueror-FSE15
+SIFTA: Scalable Analysis of Inter-App Communication;https://www.se.cs.uni-saarland.de/papers/app_analysis/;siftaeval
 VarexJ - Variability-Aware Execution for Java;http://meinicke.github.io/VarexJ/;varexj
-Variability-Aware Static Analysis at Scale: An Empirical Study;http://www.infosun.fim.uni-passau.de/se/papers/var_stat_analysis/;var_stat_analysis
-Tradeoffs in Modeling Performance of Highly-Configurable Software Systems;http://www.infosun.fim.uni-passau.de/spl/projects/tradeoffs/;tradeoffs
+Variability-Aware Static Analysis at Scale: An Empirical Study;https://www.se.cs.uni-saarland.de/papers/var_stat_analysis/;var_stat_analysis
+Tradeoffs in Modeling Performance of Highly-Configurable Software Systems;https://www.se.cs.uni-saarland.de/projects/tradeoffs/;tradeoffs


### PR DESCRIPTION
After migrating the website from the university of Passau to the Saarland university, the links from fosd.net have to be adjusted too since some of these links are now broken.